### PR TITLE
Coffee script cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ var exportsOfFile2 = require("coffee?literate!./file.litcoffee");
 }
 ```
 
+
+### Caching
+
+An option to save the result of the compilation to disk exists.
+
+
+```javascript
+    module: {
+        loaders: [
+            {
+                test: /\.coffee$/,
+                loader: 'coffee',
+                query: {
+                    cacheDirectory: '.coffee-cache'
+                }
+            }
+        ]
+    }
+```
+
 ## License
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -4,23 +4,63 @@
 */
 var coffee = require("coffee-script");
 var loaderUtils = require("loader-utils");
+var crypto = require('crypto');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
+
+var hasCreatedCacheDirectory = false
+
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
+	var loaderOptions = loaderUtils.parseQuery(this.query);
 	var coffeeRequest = loaderUtils.getRemainingRequest(this);
 	var jsRequest = loaderUtils.getCurrentRequest(this);
 	var query = loaderUtils.parseQuery(this.query);
 	var result;
+
 	try {
-		result = coffee.compile(source, {
-			literate: query.literate,
-			filename: coffeeRequest,
-			debug: this.debug,
-			bare: true,
-			sourceMap: true,
-			sourceRoot: "",
-			sourceFiles: [coffeeRequest],
-			generatedFile: jsRequest
-		});
+		var cacheDirectory = loaderOptions.cacheDirectory ? path.normalize( loaderOptions.cacheDirectory + path.sep) : false;
+
+		if (cacheDirectory && !hasCreatedCacheDirectory) {
+			mkdirp.sync(cacheDirectory);
+		}
+
+		if (cacheDirectory) {
+			var sourceMD5 = crypto.createHash("md5").update(source).digest("hex");
+			var cacheFile = path.normalize(cacheDirectory + path.sep + "coffe_loader_" + sourceMD5 + ".json");
+
+			try {
+				var cacheFileContent = fs.readFileSync(cacheFile);
+				if (cacheFileContent) {
+					result = JSON.parse(cacheFileContent);
+				}
+
+			} catch (e) {
+				result = coffee.compile(source, {
+					literate: query.literate,
+					filename: coffeeRequest,
+					debug: this.debug,
+					bare: true,
+					sourceMap: true,
+					sourceRoot: "",
+					sourceFiles: [coffeeRequest],
+					generatedFile: jsRequest
+				});
+				fs.writeFileSync(cacheFile, JSON.stringify(result));
+			}
+		} else {
+			result = coffee.compile(source, {
+				literate: query.literate,
+				filename: coffeeRequest,
+				debug: this.debug,
+				bare: true,
+				sourceMap: true,
+				sourceRoot: "",
+				sourceFiles: [coffeeRequest],
+				generatedFile: jsRequest
+			});
+		}
 	} catch (e) {
 		var err = "";
 		if (e.location == null || e.location.first_column == null || e.location.first_line == null) {

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(source) {
 	var result;
 
 	try {
-		var cacheDirectory = loaderOptions.cacheDirectory ? path.normalize( loaderOptions.cacheDirectory + path.sep) : false;
+		var cacheDirectory = loaderOptions.cacheDirectory ? path.normalize(loaderOptions.cacheDirectory + path.sep) : false;
 
 		if (cacheDirectory && !hasCreatedCacheDirectory) {
 			mkdirp.sync(cacheDirectory);
@@ -35,7 +35,6 @@ module.exports = function(source) {
 				if (cacheFileContent) {
 					result = JSON.parse(cacheFileContent);
 				}
-
 			} catch (e) {
 				result = coffee.compile(source, {
 					literate: query.literate,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"author": "Tobias Koppers @sokra",
 	"description": "coffee loader module for webpack",
 	"dependencies": {
-		"loader-utils": "0.2.x"
+		"loader-utils": "0.2.x",
+		"mkdirp": "^0.5.1"
 	},
 	"peerDependencies": {
 		"coffee-script": "1.x"


### PR DESCRIPTION
Copied from https://github.com/genintho/coffee-loader

Add an option to cache the output of the compiler to disk and reuse it the next time.
