### PR TITLE
Fix breaking bug for certain webpack configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ module.exports = function(source) {
 		}
 		throw new Error(err);
 	}
-	var map = JSON.parse(result.v3SourceMap);
-	map.sourcesContent = [source];
-	this.callback(null, result.js, map);
+	if( result.v3SourceMap ){
+		var map = JSON.parse(result.v3SourceMap);
+		map.sourcesContent = [source];
+		this.callback(null, result.js, map);
+	} else {
+		this.callback(null, result);
+	}
 }


### PR DESCRIPTION
coffee-loader will cause the webpack compilation to crash with the following error:
```
Module build failed: SyntaxError: Unexpected token u
    at Object.parse (native)
    at Object.module.exports (workspace/node_modules/coffee-loader/index.js:39:18)
```
Upon inspection, the the result that this JSON.parse is attempting to parse shows a successfully-compiled coffeescript string/buffer, it does not have a v3SourceMap attribute, which makes JSON.parse attempt to parse undefined. I'm not doing anything especially unique with my webpack configuration except perhaps using the multi-compiler, I am not sourcemapping them, nor am I minifying.

Thank you for the great loader. I've enjoyed using it in so many of my projects.