### PR TITLE
Update README to use -loader suffix to support webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## Usage
 
 ``` javascript
-var exportsOfFile = require("coffee!./file.coffee");
+var exportsOfFile = require("coffee-loader!./file.coffee");
 // => return exports of executed and compiled file.coffee
 
-var exportsOfFile2 = require("coffee?literate!./file.litcoffee");
+var exportsOfFile2 = require("coffee-loader?literate!./file.litcoffee");
 // can also compile literate files.
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra